### PR TITLE
fix: change Factor Comparison chart scale from percentages to decimals

### DIFF
--- a/src/FactorComparisonChart.js
+++ b/src/FactorComparisonChart.js
@@ -247,7 +247,7 @@ function FactorComparisonChart({ allData, selectedRegion, selectedYear, availabl
               type="number"
               domain={[0, 1]}
               ticks={[0, 0.25, 0.5, 0.75, 1]}
-              tickFormatter={(v) => `${Math.round(v * 100)}%`}
+              tickFormatter={(v) => v.toFixed(2)}
               tick={{ fontSize: 14, fill: COLORS.text, fontWeight: 500 }}
               axisLine={false}
               tickLine={false}
@@ -273,7 +273,7 @@ function FactorComparisonChart({ allData, selectedRegion, selectedYear, availabl
                 <LabelList
                   dataKey={country}
                   position="right"
-                  formatter={(value) => value ? `${Math.round(value * 100)}%` : ''}
+                  formatter={(value) => value ? value.toFixed(2) : ''}
                   style={{
                     fontSize: '15px',
                     fontWeight: '600',


### PR DESCRIPTION
Updated FactorComparisonChart.js to display values in 0.00-1.00 decimal format instead of 0%-100% percentage format:
- X-axis tick formatter now uses v.toFixed(2)
- Bar label formatter now uses value.toFixed(2)

This change aligns the Factor Comparison chart with other charts in the dashboard that use the 0-1 decimal scale.

Fixes #1

Generated with [Claude Code](https://claude.ai/code)