### PR TITLE
Fix X-axis label overlap in time series chart

### DIFF
--- a/src/TimeSeriesChart.js
+++ b/src/TimeSeriesChart.js
@@ -65,6 +65,7 @@ function TimeSeriesChart({ allData, country, variable, label, selectedRegion, re
               axisLine={{ stroke: TS_COLORS.grid, strokeWidth: 1 }}
               tickLine={{ stroke: TS_COLORS.axis, strokeWidth: 1 }}
               interval={0}
+              padding={{ left: 20, right: 0 }}
             />
             <YAxis
               domain={[yMin, yMax]}


### PR DESCRIPTION
Adds left padding to X-axis to prevent year labels from overlapping with Y-axis score labels.

Fixes #4

Generated with [Claude Code](https://claude.ai/code)